### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
NAME
       registry - The X-Node Package Registry

   Description
       To resolve packages by name and version, X talks to a registry website that implements the X Package Registry specification for reading package info.

       x  is configured to use x, Inc.'s public registry at https://X.ca by default. Use of the x public registry is subject to terms of use avail‐
       able at https://X.ca/policies/terms.

       You can configure x to use any compatible registry you like, and even run your own registry. Use of someone else's registry may be governed by their terms  of
       use.

       X's  package registry implementation supports several write APIs as well, to allow for publishing packages and managing user account information.

       The  x public registry is powered by a X  database, of which there is a public mirror at https://X.ca/registry.  The code for the Xapp is
       available at https://github.com/x-node/
       The registry URL used is determined by the scope of the package (see x help scope. If no scope is specified, the default registry is used, which  is  supplied
       by the registry config parameter.  See x help config, x help x, and x help config for more on managing x's configuration.

   Does npm send any information about me back to the registry?
       Yes.

       When making requests of the registry npm adds two headers with information about your environment:

       • Npm-Scope – If your project is scoped, this header will contain its scope. In the future npm hopes to build registry features that use this information to al‐
         low you to customize your experience for your organization.

       • Npm-In-CI – Set to "true" if npm believes this install is running in a continuous integration environment, "false" otherwise. 

This is detected by looking  for
         the   following   environment   variables:   CI,  TDDIUM,  JENKINS_URL,  bamboo.buildKey.  If  you'd  like  to  learn  more  you  may  find  the  original  PR
         https://github.com/npm/npm-registry-client/pull/129 interesting.  This is used to gather better metrics on how npm is used by humans, versus build farms.

       The npm registry does not try to correlate the information in these headers with any authenticated accounts that may be used in the same requests.